### PR TITLE
Replace log with logrus

### DIFF
--- a/openstack/compute_instance_v2.go
+++ b/openstack/compute_instance_v2.go
@@ -11,7 +11,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/compute_interface_attach_v2.go
+++ b/openstack/compute_interface_attach_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/compute_secgroup_v2.go
+++ b/openstack/compute_secgroup_v2.go
@@ -3,7 +3,7 @@ package openstack
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/compute_volume_attach_v2.go
+++ b/openstack/compute_volume_attach_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/data_source_openstack_blockstorage_snapshot_v2.go
+++ b/openstack/data_source_openstack_blockstorage_snapshot_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/snapshots"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/data_source_openstack_blockstorage_snapshot_v3.go
+++ b/openstack/data_source_openstack_blockstorage_snapshot_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/data_source_openstack_blockstorage_volume_v2.go
+++ b/openstack/data_source_openstack_blockstorage_volume_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 

--- a/openstack/data_source_openstack_blockstorage_volume_v3.go
+++ b/openstack/data_source_openstack_blockstorage_volume_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 

--- a/openstack/data_source_openstack_compute_flavor_v2.go
+++ b/openstack/data_source_openstack_compute_flavor_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"

--- a/openstack/data_source_openstack_compute_instance_v2.go
+++ b/openstack/data_source_openstack_compute_instance_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones"

--- a/openstack/data_source_openstack_compute_keypair_v2.go
+++ b/openstack/data_source_openstack_compute_keypair_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/data_source_openstack_containerinfra_cluster_v1.go
+++ b/openstack/data_source_openstack_containerinfra_cluster_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clusters"

--- a/openstack/data_source_openstack_containerinfra_clustertemplate_v1.go
+++ b/openstack/data_source_openstack_containerinfra_clustertemplate_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/containerinfra/v1/clustertemplates"

--- a/openstack/data_source_openstack_dns_zone_v2.go
+++ b/openstack/data_source_openstack_dns_zone_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"

--- a/openstack/data_source_openstack_fw_policy_v1.go
+++ b/openstack/data_source_openstack_fw_policy_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/data_source_openstack_identity_auth_scope_v3.go
+++ b/openstack/data_source_openstack_identity_auth_scope_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )

--- a/openstack/data_source_openstack_identity_endpoint_v3.go
+++ b/openstack/data_source_openstack_identity_endpoint_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/services"

--- a/openstack/data_source_openstack_identity_group_v3.go
+++ b/openstack/data_source_openstack_identity_group_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/data_source_openstack_identity_project_v3.go
+++ b/openstack/data_source_openstack_identity_project_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"

--- a/openstack/data_source_openstack_identity_role_v3.go
+++ b/openstack/data_source_openstack_identity_role_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/data_source_openstack_identity_service_v3.go
+++ b/openstack/data_source_openstack_identity_service_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/services"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/data_source_openstack_identity_user_v3.go
+++ b/openstack/data_source_openstack_identity_user_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"

--- a/openstack/data_source_openstack_images_image_ids_v2.go
+++ b/openstack/data_source_openstack_images_image_ids_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"

--- a/openstack/data_source_openstack_images_image_v2.go
+++ b/openstack/data_source_openstack_images_image_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"time"
 

--- a/openstack/data_source_openstack_keymanager_container_v1.go
+++ b/openstack/data_source_openstack_keymanager_container_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/keymanager/v1/acls"

--- a/openstack/data_source_openstack_keymanager_secret_v1.go
+++ b/openstack/data_source_openstack_keymanager_secret_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/openstack/data_source_openstack_networking_addressscope_v2.go
+++ b/openstack/data_source_openstack_networking_addressscope_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/addressscopes"
 

--- a/openstack/data_source_openstack_networking_floatingip_v2.go
+++ b/openstack/data_source_openstack_networking_floatingip_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"

--- a/openstack/data_source_openstack_networking_network_v2.go
+++ b/openstack/data_source_openstack_networking_network_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 

--- a/openstack/data_source_openstack_networking_port_ids_v2.go
+++ b/openstack/data_source_openstack_networking_port_ids_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"

--- a/openstack/data_source_openstack_networking_port_v2.go
+++ b/openstack/data_source_openstack_networking_port_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/data_source_openstack_networking_qos_bandwidth_limit_rule_v2.go
+++ b/openstack/data_source_openstack_networking_qos_bandwidth_limit_rule_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/openstack/data_source_openstack_networking_qos_dscp_marking_rule_v2.go
+++ b/openstack/data_source_openstack_networking_qos_dscp_marking_rule_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/openstack/data_source_openstack_networking_qos_minimum_bandwidth_rule_v2.go
+++ b/openstack/data_source_openstack_networking_qos_minimum_bandwidth_rule_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/openstack/data_source_openstack_networking_qos_policy_v2.go
+++ b/openstack/data_source_openstack_networking_qos_policy_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/openstack/data_source_openstack_networking_router_v2.go
+++ b/openstack/data_source_openstack_networking_router_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"

--- a/openstack/data_source_openstack_networking_secgroup_v2.go
+++ b/openstack/data_source_openstack_networking_secgroup_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"

--- a/openstack/data_source_openstack_networking_subnet_v2.go
+++ b/openstack/data_source_openstack_networking_subnet_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/data_source_openstack_networking_subnetpool_v2.go
+++ b/openstack/data_source_openstack_networking_subnetpool_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/openstack/data_source_openstack_networking_trunk_v2.go
+++ b/openstack/data_source_openstack_networking_trunk_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/data_source_openstack_sharedfilesystem_share_v2.go
+++ b/openstack/data_source_openstack_sharedfilesystem_share_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/data_source_openstack_sharedfilesystem_sharenetwork_v2.go
+++ b/openstack/data_source_openstack_sharedfilesystem_sharenetwork_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/sharenetworks"

--- a/openstack/data_source_openstack_sharedfilesystem_snapshot_v2.go
+++ b/openstack/data_source_openstack_sharedfilesystem_snapshot_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/dns_recordset_v2.go
+++ b/openstack/dns_recordset_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/openstack/dns_zone_v2.go
+++ b/openstack/dns_zone_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 

--- a/openstack/identity_application_credential_v3.go
+++ b/openstack/identity_application_credential_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/applicationcredentials"

--- a/openstack/images_image_v2.go
+++ b/openstack/images_image_v2.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/openstack/keymanager_secret_v1.go
+++ b/openstack/keymanager_secret_v1.go
@@ -3,7 +3,7 @@ package openstack
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/lb_v2_shared.go
+++ b/openstack/lb_v2_shared.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/networking_port_v2.go
+++ b/openstack/networking_port_v2.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/dns"

--- a/openstack/networking_router_interface_v2.go
+++ b/openstack/networking_router_interface_v2.go
@@ -1,7 +1,7 @@
 package openstack
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"

--- a/openstack/networking_secgroup_v2.go
+++ b/openstack/networking_secgroup_v2.go
@@ -1,7 +1,7 @@
 package openstack
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 

--- a/openstack/networking_subnet_v2.go
+++ b/openstack/networking_subnet_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"

--- a/openstack/orchestration_stack_v1.go
+++ b/openstack/orchestration_stack_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_blockstorage_quotaset_v2.go
+++ b/openstack/resource_openstack_blockstorage_quotaset_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets"

--- a/openstack/resource_openstack_blockstorage_quotaset_v3.go
+++ b/openstack/resource_openstack_blockstorage_quotaset_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/quotasets"

--- a/openstack/resource_openstack_blockstorage_volume_attach_v2.go
+++ b/openstack/resource_openstack_blockstorage_volume_attach_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"

--- a/openstack/resource_openstack_blockstorage_volume_attach_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_attach_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"

--- a/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_blockstorage_volume_v2.go
+++ b/openstack/resource_openstack_blockstorage_volume_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_blockstorage_volume_v3.go
+++ b/openstack/resource_openstack_blockstorage_volume_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_compute_flavor_access_v2.go
+++ b/openstack/resource_openstack_compute_flavor_access_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_compute_flavor_v2.go
+++ b/openstack/resource_openstack_compute_flavor_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_compute_floatingip_associate_v2.go
+++ b/openstack/resource_openstack_compute_floatingip_associate_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_compute_floatingip_v2.go
+++ b/openstack/resource_openstack_compute_floatingip_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_compute_instance_v2.go
+++ b/openstack/resource_openstack_compute_instance_v2.go
@@ -5,7 +5,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"time"

--- a/openstack/resource_openstack_compute_interface_attach_v2.go
+++ b/openstack/resource_openstack_compute_interface_attach_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces"

--- a/openstack/resource_openstack_compute_keypair_v2.go
+++ b/openstack/resource_openstack_compute_keypair_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_compute_quotaset_v2.go
+++ b/openstack/resource_openstack_compute_quotaset_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/quotasets"

--- a/openstack/resource_openstack_compute_secgroup_v2.go
+++ b/openstack/resource_openstack_compute_secgroup_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/openstack/resource_openstack_compute_servergroup_v2.go
+++ b/openstack/resource_openstack_compute_servergroup_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_compute_volume_attach_v2.go
+++ b/openstack/resource_openstack_compute_volume_attach_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_containerinfra_cluster_v1.go
+++ b/openstack/resource_openstack_containerinfra_cluster_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 	"time"

--- a/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
+++ b/openstack/resource_openstack_containerinfra_clustertemplate_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"time"
 

--- a/openstack/resource_openstack_db_configuration_v1.go
+++ b/openstack/resource_openstack_db_configuration_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/db/v1/configurations"

--- a/openstack/resource_openstack_db_instance_v1.go
+++ b/openstack/resource_openstack_db_instance_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/db/v1/databases"

--- a/openstack/resource_openstack_dns_recordset_v2.go
+++ b/openstack/resource_openstack_dns_recordset_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/recordsets"

--- a/openstack/resource_openstack_dns_zone_v2.go
+++ b/openstack/resource_openstack_dns_zone_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/dns/v2/zones"

--- a/openstack/resource_openstack_fw_firewall_v1.go
+++ b/openstack/resource_openstack_fw_firewall_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls"

--- a/openstack/resource_openstack_fw_policy_v1.go
+++ b/openstack/resource_openstack_fw_policy_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies"

--- a/openstack/resource_openstack_fw_rule_v1.go
+++ b/openstack/resource_openstack_fw_rule_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules"

--- a/openstack/resource_openstack_identity_application_credential_v3.go
+++ b/openstack/resource_openstack_identity_application_credential_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_identity_ec2_credential_v3.go
+++ b/openstack/resource_openstack_identity_ec2_credential_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/ec2credentials"

--- a/openstack/resource_openstack_identity_endpoint_v3.go
+++ b/openstack/resource_openstack_identity_endpoint_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/endpoints"

--- a/openstack/resource_openstack_identity_group_v3.go
+++ b/openstack/resource_openstack_identity_group_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_identity_project_v3.go
+++ b/openstack/resource_openstack_identity_project_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_identity_role_assignment_v3.go
+++ b/openstack/resource_openstack_identity_role_assignment_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_identity_role_v3.go
+++ b/openstack/resource_openstack_identity_role_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/roles"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_identity_service_v3.go
+++ b/openstack/resource_openstack_identity_service_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/services"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_identity_user_v3.go
+++ b/openstack/resource_openstack_identity_user_v3.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_images_image_access_accept_v2.go
+++ b/openstack/resource_openstack_images_image_access_accept_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/openstack/resource_openstack_images_image_access_v2.go
+++ b/openstack/resource_openstack_images_image_access_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/members"

--- a/openstack/resource_openstack_images_image_v2.go
+++ b/openstack/resource_openstack_images_image_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"time"

--- a/openstack/resource_openstack_keymanager_container_v1.go
+++ b/openstack/resource_openstack_keymanager_container_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_keymanager_order_v1.go
+++ b/openstack/resource_openstack_keymanager_order_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/keymanager/v1/orders"

--- a/openstack/resource_openstack_keymanager_secret_v1.go
+++ b/openstack/resource_openstack_keymanager_secret_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/openstack/resource_openstack_lb_l7policy_v2.go
+++ b/openstack/resource_openstack_lb_l7policy_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"time"
 

--- a/openstack/resource_openstack_lb_l7rule_v2.go
+++ b/openstack/resource_openstack_lb_l7rule_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/openstack/resource_openstack_lb_listener_v2.go
+++ b/openstack/resource_openstack_lb_listener_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_lb_member_v1.go
+++ b/openstack/resource_openstack_lb_member_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_lb_member_v2.go
+++ b/openstack/resource_openstack_lb_member_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/openstack/resource_openstack_lb_members_v2.go
+++ b/openstack/resource_openstack_lb_members_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_lb_monitor_v1.go
+++ b/openstack/resource_openstack_lb_monitor_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"time"
 

--- a/openstack/resource_openstack_lb_monitor_v2.go
+++ b/openstack/resource_openstack_lb_monitor_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/openstack/resource_openstack_lb_pool_v1.go
+++ b/openstack/resource_openstack_lb_pool_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_lb_pool_v2.go
+++ b/openstack/resource_openstack_lb_pool_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_lb_vip_v1.go
+++ b/openstack/resource_openstack_lb_vip_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_networking_addressscope_v2.go
+++ b/openstack/resource_openstack_networking_addressscope_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_networking_floatingip_associate_v2.go
+++ b/openstack/resource_openstack_networking_floatingip_associate_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/openstack/resource_openstack_networking_floatingip_v2.go
+++ b/openstack/resource_openstack_networking_floatingip_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"time"
 

--- a/openstack/resource_openstack_networking_network_v2.go
+++ b/openstack/resource_openstack_networking_network_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"time"
 

--- a/openstack/resource_openstack_networking_port_secgroup_associate_v2.go
+++ b/openstack/resource_openstack_networking_port_secgroup_associate_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_networking_port_v2.go
+++ b/openstack/resource_openstack_networking_port_v2.go
@@ -3,7 +3,7 @@ package openstack
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_networking_qos_bandwidth_limit_rule_v2.go
+++ b/openstack/resource_openstack_networking_qos_bandwidth_limit_rule_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_networking_qos_dscp_marking_rule_v2.go
+++ b/openstack/resource_openstack_networking_qos_dscp_marking_rule_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_networking_qos_minimum_bandwidth_rule_v2.go
+++ b/openstack/resource_openstack_networking_qos_minimum_bandwidth_rule_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_networking_qos_policy_v2.go
+++ b/openstack/resource_openstack_networking_qos_policy_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_networking_quota_v2.go
+++ b/openstack/resource_openstack_networking_quota_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/quotas"

--- a/openstack/resource_openstack_networking_rbac_policy_v2.go
+++ b/openstack/resource_openstack_networking_rbac_policy_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"

--- a/openstack/resource_openstack_networking_router_interface_v2.go
+++ b/openstack/resource_openstack_networking_router_interface_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_networking_router_route_v2.go
+++ b/openstack/resource_openstack_networking_router_route_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/openstack/resource_openstack_networking_router_v2.go
+++ b/openstack/resource_openstack_networking_router_v2.go
@@ -3,7 +3,7 @@ package openstack
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_networking_secgroup_rule_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_rule_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/openstack/resource_openstack_networking_secgroup_v2.go
+++ b/openstack/resource_openstack_networking_secgroup_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_networking_subnet_route_v2.go
+++ b/openstack/resource_openstack_networking_subnet_route_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 

--- a/openstack/resource_openstack_networking_subnet_v2.go
+++ b/openstack/resource_openstack_networking_subnet_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"

--- a/openstack/resource_openstack_networking_subnetpool_v2.go
+++ b/openstack/resource_openstack_networking_subnetpool_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_networking_trunk_v2.go
+++ b/openstack/resource_openstack_networking_trunk_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_objectstorage_container_v1.go
+++ b/openstack/resource_openstack_objectstorage_container_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_objectstorage_object_v1.go
+++ b/openstack/resource_openstack_objectstorage_object_v1.go
@@ -3,7 +3,7 @@ package openstack
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"time"
 

--- a/openstack/resource_openstack_objectstorage_object_v1_test.go
+++ b/openstack/resource_openstack_objectstorage_object_v1_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"testing"

--- a/openstack/resource_openstack_objectstorage_tempurl_v1.go
+++ b/openstack/resource_openstack_objectstorage_tempurl_v1.go
@@ -4,7 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"strconv"
 	"time"

--- a/openstack/resource_openstack_orchestration_stack_v1.go
+++ b/openstack/resource_openstack_orchestration_stack_v1.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud/openstack/orchestration/v1/stacks"

--- a/openstack/resource_openstack_sharedfilesystem_securityservice_v2.go
+++ b/openstack/resource_openstack_sharedfilesystem_securityservice_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_sharedfilesystem_share_access_v2.go
+++ b/openstack/resource_openstack_sharedfilesystem_share_access_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/openstack/resource_openstack_sharedfilesystem_share_v2.go
+++ b/openstack/resource_openstack_sharedfilesystem_share_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/openstack/resource_openstack_sharedfilesystem_sharenetwork_v2.go
+++ b/openstack/resource_openstack_sharedfilesystem_sharenetwork_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/openstack/resource_openstack_vpnaas_endpoint_group_v2.go
+++ b/openstack/resource_openstack_vpnaas_endpoint_group_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_vpnaas_ike_policy_v2.go
+++ b/openstack/resource_openstack_vpnaas_ike_policy_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_vpnaas_ipsec_policy_v2.go
+++ b/openstack/resource_openstack_vpnaas_ipsec_policy_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_vpnaas_service_v2.go
+++ b/openstack/resource_openstack_vpnaas_service_v2.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud"

--- a/openstack/resource_openstack_vpnaas_site_connection.go
+++ b/openstack/resource_openstack_vpnaas_site_connection.go
@@ -2,7 +2,7 @@ package openstack
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/gophercloud/gophercloud"

--- a/vendor/github.com/aws/aws-sdk-go/aws/logger.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/logger.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/golang/protobuf/proto/clone.go
+++ b/vendor/github.com/golang/protobuf/proto/clone.go
@@ -36,7 +36,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/golang/protobuf/proto/equal.go
+++ b/vendor/github.com/golang/protobuf/proto/equal.go
@@ -35,7 +35,7 @@ package proto
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 )

--- a/vendor/github.com/golang/protobuf/proto/lib.go
+++ b/vendor/github.com/golang/protobuf/proto/lib.go
@@ -224,7 +224,7 @@ To create and play with a Test object:
 	package main
 
 	import (
-		"log"
+		log "github.com/sourcegraph-ce/logrus"
 
 		"github.com/golang/protobuf/proto"
 		pb "./example.pb"
@@ -266,7 +266,7 @@ package proto
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/golang/protobuf/proto/properties.go
+++ b/vendor/github.com/golang/protobuf/proto/properties.go
@@ -37,7 +37,7 @@ package proto
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/golang/protobuf/proto/text.go
+++ b/vendor/github.com/golang/protobuf/proto/text.go
@@ -40,7 +40,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"reflect"
 	"sort"

--- a/vendor/github.com/gophercloud/utils/client/client.go
+++ b/vendor/github.com/gophercloud/utils/client/client.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"sort"
 	"strings"

--- a/vendor/github.com/gophercloud/utils/terraform/auth/config.go
+++ b/vendor/github.com/gophercloud/utils/terraform/auth/config.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 

--- a/vendor/github.com/gophercloud/utils/terraform/auth/util.go
+++ b/vendor/github.com/gophercloud/utils/terraform/auth/util.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/go-hclog/intlogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/intlogger.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"runtime"
 	"sort"

--- a/vendor/github.com/hashicorp/go-hclog/logger.go
+++ b/vendor/github.com/hashicorp/go-hclog/logger.go
@@ -2,7 +2,7 @@ package hclog
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/go-hclog/nulllogger.go
+++ b/vendor/github.com/hashicorp/go-hclog/nulllogger.go
@@ -3,7 +3,7 @@ package hclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // NewNullLogger instantiates a Logger for which all calls

--- a/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/grpc_broker.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/mux_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/mux_broker.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/binary"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/rpc_server.go
+++ b/vendor/github.com/hashicorp/go-plugin/rpc_server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/rpc"
 	"sync"

--- a/vendor/github.com/hashicorp/go-plugin/server.go
+++ b/vendor/github.com/hashicorp/go-plugin/server.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"os"
 	"os/signal"

--- a/vendor/github.com/hashicorp/go-plugin/stream.go
+++ b/vendor/github.com/hashicorp/go-plugin/stream.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func copyStream(name string, dst io.Writer, src io.Reader) {

--- a/vendor/github.com/hashicorp/hcl/v2/doc.go
+++ b/vendor/github.com/hashicorp/hcl/v2/doc.go
@@ -9,7 +9,7 @@
 //     package main
 //
 //     import (
-//     	"log"
+//     	log "github.com/sourcegraph-ce/logrus"
 //     	"github.com/hashicorp/hcl/v2/hclsimple"
 //     )
 //

--- a/vendor/github.com/hashicorp/logutils/level.go
+++ b/vendor/github.com/hashicorp/logutils/level.go
@@ -51,7 +51,7 @@ func (f *LevelFilter) Check(line []byte) bool {
 
 func (f *LevelFilter) Write(p []byte) (n int, err error) {
 	// Note in general that io.Writer can receive any byte sequence
-	// to write, but the "log" package always guarantees that we only
+	// to write, but the log "github.com/sourcegraph-ce/logrus" package always guarantees that we only
 	// get a single line. We use that as a slight optimization within
 	// this method, assuming we're dealing with a single, complete line
 	// of log data.

--- a/vendor/github.com/hashicorp/terraform-exec/tfinstall/tfinstall.go
+++ b/vendor/github.com/hashicorp/terraform-exec/tfinstall/tfinstall.go
@@ -3,7 +3,7 @@ package tfinstall
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"os/exec"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/logging.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/logging.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"syscall"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/transport.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/logging/transport.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/http/httputil"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv/mutexkv.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv/mutexkv.go
@@ -1,7 +1,7 @@
 package mutexkv
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 )
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/state.go
@@ -1,7 +1,7 @@
 package resource
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"reflect"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_config.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_import_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_import_state.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_new.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/resource/testing_new.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 	"testing"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/field_reader_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/field_reader_config.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource.go
@@ -3,7 +3,7 @@ package schema
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_data.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_timeout.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource_timeout.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/hcl2shim"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/httpclient/useragent.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/httpclient/useragent.go
@@ -2,7 +2,7 @@ package httpclient
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/marshal.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/marshal.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/walk.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/dag/walk.go
@@ -2,7 +2,7 @@ package dag
 
 import (
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"time"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin/grpc_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin/grpc_provider.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/httpclient/client.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/httpclient/client.go
@@ -2,7 +2,7 @@ package httpclient
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/from_module.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/from_module.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/earlyconfig"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/getter.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/getter.go
@@ -2,7 +2,7 @@ package initwd
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/module_install.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/initwd/module_install.go
@@ -2,7 +2,7 @@ package initwd
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/eval.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/eval.go
@@ -2,7 +2,7 @@ package lang
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/hcl/v2"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs/encoding.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/funcs/encoding.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"unicode/utf8"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/functions.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/lang/functions.go
@@ -75,7 +75,7 @@ func (s *Scope) Functions() map[string]function.Function {
 			"keys":             funcs.KeysFunc,
 			"length":           funcs.LengthFunc,
 			"list":             funcs.ListFunc,
-			"log":              funcs.LogFunc,
+			log "github.com/sourcegraph-ce/logrus":              funcs.LogFunc,
 			"lookup":           funcs.LookupFunc,
 			"lower":            stdlib.LowerFunc,
 			"map":              funcs.MapFunc,

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/modsdir/manifest.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/modsdir/manifest.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert/schema.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/convert/schema.go
@@ -2,7 +2,7 @@ package convert
 
 import (
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/find.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/find.go
@@ -2,7 +2,7 @@ package discovery
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/get.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/plugin/discovery/get.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"path/filepath"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/registry/client.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/registry/client.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"path"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version1_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version1_upgrade.go
@@ -2,7 +2,7 @@ package statefile
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/mitchellh/copystructure"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version2_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/statefile/version2_upgrade.go
@@ -2,7 +2,7 @@ package statefile
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/sync.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/states/sync.go
@@ -1,7 +1,7 @@
 package states
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provider.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"context"
 	"errors"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provisioner.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/plugin/grpc_provisioner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	plugin "github.com/hashicorp/go-plugin"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context_input.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/context_input.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 
 	"github.com/hashicorp/hcl/v2"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/diff.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"regexp"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_apply.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_apply.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_context_builtin.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_context_builtin.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count_boundary.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_count_boundary.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_import_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_import_state.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_lang.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_lang.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_output.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_output.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_provider.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl/v2"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_read_data.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_read_data.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/zclconf/go-cty/cty"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_refresh.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_refresh.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/zclconf/go-cty/cty"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state_upgrade.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_state_upgrade.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_validate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_validate.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_variable.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/eval_variable.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder_refresh.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_builder_refresh.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_walk_context.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/graph_walk_context.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/zclconf/go-cty/cty"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_abstract.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_abstract.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_apply.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_apply.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_destroy.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_destroy.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_plan.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_plan.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/tfdiags"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_refresh.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/node_resource_refresh.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/providers"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/schemas.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/schemas.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"reflect"
 	"sort"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state_upgrade_v2_to_v3.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/state_upgrade_v2_to_v3.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_config_resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_config_resource.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_schema.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_schema.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs/configschema"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_attach_state.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_config.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_config.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_cbd.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_cbd.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_edge.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_destroy_edge.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_diff.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/plans"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_expand.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_expand.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_count.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_count.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_output.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_output.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_resource.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_orphan_resource.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_output.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_output.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provider.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provider.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provisioner.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_provisioner.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_reference.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_reference.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_removed_modules.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_removed_modules.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/configs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_state.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_state.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/states"
 )

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_targets.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/terraform/transform_targets.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/internal/addrs"
 	"github.com/hashicorp/terraform-plugin-sdk/internal/dag"

--- a/vendor/github.com/hashicorp/terraform-svchost/disco/disco.go
+++ b/vendor/github.com/hashicorp/terraform-svchost/disco/disco.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"mime"
 	"net/http"
 	"net/url"

--- a/vendor/github.com/hashicorp/terraform-svchost/disco/host.go
+++ b/vendor/github.com/hashicorp/terraform-svchost/disco/host.go
@@ -3,7 +3,7 @@ package disco
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/github.com/hashicorp/yamux/mux.go
+++ b/vendor/github.com/hashicorp/yamux/mux.go
@@ -3,7 +3,7 @@ package yamux
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"time"
 )

--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"strings"

--- a/vendor/github.com/mitchellh/cli/help.go
+++ b/vendor/github.com/mitchellh/cli/help.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 )

--- a/vendor/github.com/mitchellh/go-testing-interface/testing.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing.go
@@ -4,7 +4,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/mitchellh/go-testing-interface/testing_go19.go
+++ b/vendor/github.com/mitchellh/go-testing-interface/testing_go19.go
@@ -9,7 +9,7 @@ package testing
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // T is the interface that mimics the standard library *testing.T.

--- a/vendor/github.com/posener/complete/log.go
+++ b/vendor/github.com/posener/complete/log.go
@@ -2,7 +2,7 @@ package complete
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/spf13/afero/memmap.go
+++ b/vendor/github.com/spf13/afero/memmap.go
@@ -15,7 +15,7 @@ package afero
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"strings"

--- a/vendor/golang.org/x/crypto/ssh/channel.go
+++ b/vendor/golang.org/x/crypto/ssh/channel.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 )
 

--- a/vendor/golang.org/x/crypto/ssh/handshake.go
+++ b/vendor/golang.org/x/crypto/ssh/handshake.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 )

--- a/vendor/golang.org/x/crypto/ssh/mux.go
+++ b/vendor/golang.org/x/crypto/ssh/mux.go
@@ -8,7 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"sync/atomic"
 )

--- a/vendor/golang.org/x/crypto/ssh/transport.go
+++ b/vendor/golang.org/x/crypto/ssh/transport.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // debugTransport if set, will print packet types as they go over the

--- a/vendor/golang.org/x/net/http2/frame.go
+++ b/vendor/golang.org/x/net/http2/frame.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"sync"
 

--- a/vendor/golang.org/x/net/http2/server.go
+++ b/vendor/golang.org/x/net/http2/server.go
@@ -33,7 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"net/http"

--- a/vendor/golang.org/x/net/http2/transport.go
+++ b/vendor/golang.org/x/net/http2/transport.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	mathrand "math/rand"
 	"net"

--- a/vendor/golang.org/x/net/http2/write.go
+++ b/vendor/golang.org/x/net/http2/write.go
@@ -7,7 +7,7 @@ package http2
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 

--- a/vendor/golang.org/x/net/internal/timeseries/timeseries.go
+++ b/vendor/golang.org/x/net/internal/timeseries/timeseries.go
@@ -7,7 +7,7 @@ package timeseries // import "golang.org/x/net/internal/timeseries"
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/golang.org/x/net/trace/events.go
+++ b/vendor/golang.org/x/net/trace/events.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"runtime"
 	"sort"

--- a/vendor/golang.org/x/net/trace/histogram.go
+++ b/vendor/golang.org/x/net/trace/histogram.go
@@ -10,7 +10,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"sync"
 

--- a/vendor/golang.org/x/net/trace/trace.go
+++ b/vendor/golang.org/x/net/trace/trace.go
@@ -68,7 +68,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
+++ b/vendor/golang.org/x/oauth2/google/appengine_gen2_flex.go
@@ -10,7 +10,7 @@ package google
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"golang.org/x/oauth2"

--- a/vendor/golang.org/x/text/unicode/bidi/core.go
+++ b/vendor/golang.org/x/text/unicode/bidi/core.go
@@ -4,7 +4,7 @@
 
 package bidi
 
-import "log"
+import log "github.com/sourcegraph-ce/logrus"
 
 // This implementation is a port based on the reference implementation found at:
 // https://www.unicode.org/Public/PROGRAMS/BidiReferenceJava/

--- a/vendor/google.golang.org/appengine/internal/api.go
+++ b/vendor/google.golang.org/appengine/internal/api.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 	"net/url"

--- a/vendor/google.golang.org/appengine/internal/identity_vm.go
+++ b/vendor/google.golang.org/appengine/internal/identity_vm.go
@@ -7,7 +7,7 @@
 package internal
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/vendor/google.golang.org/appengine/internal/main_vm.go
+++ b/vendor/google.golang.org/appengine/internal/main_vm.go
@@ -8,7 +8,7 @@ package internal
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vendor/google.golang.org/appengine/internal/net.go
+++ b/vendor/google.golang.org/appengine/internal/net.go
@@ -8,7 +8,7 @@ package internal
 // It is only used for API calls.
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"runtime"
 	"sync"

--- a/vendor/google.golang.org/grpc/grpclog/loggerv2.go
+++ b/vendor/google.golang.org/grpc/grpclog/loggerv2.go
@@ -21,7 +21,7 @@ package grpclog
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strconv"
 )


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-openstack', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
examples
test-infra
openstack
scripts
.github
vendor
website
assets
.git
app-with-networking
attach-format-mount-volume
multiple-vm-with-floating-ip
standard
files
openstack
aws
packer
packer
go.opencensus.io
cloud.google.com
gopkg.in
google.golang.org
golang.org
github.com
plugin
stats
internal
resource
tag
trace
metric
ochttp
propagation
b3
view
internal
tagencoding
tracestate
internal
propagation
metricproducer
metricdata
go
storage
internal
iam
compute
optional
trace
version
metadata
yaml.v2
grpc
genproto
appengine
api
keepalive
grpclog
naming
health
stats
binarylog
codes
reflection
internal
backoff
connectivity
attributes
test
status
credentials
serviceconfig
resolver
tap
peer
balancer
encoding
metadata
grpc_health_v1
grpc_binarylog_v1
grpc_reflection_v1alpha
grpcrand
syscall
transport
envconfig
binarylog
buffer
backoff
grpcsync
resolver
channelz
balancerload
dns
passthrough
bufconn
internal
base
roundrobin
proto
googleapis
rpc
iam
type
api
code
status
v1
expr
annotations
datastore
urlfetch
internal
internal
cloudkey
cloudpb
app_identity
datastore
urlfetch
base
log
remote_api
modules
storage
transport
googleapi
option
internal
gensupport
iterator
v1
http
internal
propagation
transport
internal
uritemplates
x
crypto
net
sys
oauth2
text
cast5
poly1305
ssh
internal
openpgp
curve25519
blowfish
bcrypt
chacha20
ed25519
subtle
s2k
armor
packet
elgamal
errors
internal
edwards25519
http
idna
internal
context
http2
trace
httpguts
timeseries
ctxhttp
hpack
unix
windows
cpu
jwt
internal
google
jws
unicode
secure
transform
encoding
bidi
norm
bidirule
internal
charmap
identifier
ulikunitz
stretchr
fatih
googleapis
gophercloud
zclconf
apparentlymart
golang
oklog
jmespath
google
hashicorp
posener
spf13
mitchellh
davecgh
pmezard
aws
vmihailenco
mattn
armon
bgentry
agext
xz
lzma
internal
hash
xlog
testify
assert
color
gax-go
v2
utils
gophercloud
openstack
terraform
client
env
compute
clientconfig
v2
images
flavors
auth
openstack
internal
pagination
testhelper
utils
networking
keymanager
containerinfra
identity
objectstorage
db
imageservice
blockstorage
orchestration
dns
common
sharedfilesystems
compute
loadbalancer
v2
ports
extensions
networks
subnets
provider
security
portsecurity
subnetpools
qos
extradhcpopts
attributestags
vpnaas
rbacpolicies
vlantransparent
dns
trunks
lbaas_v2
external
fwaas
portsbinding
lbaas
mtu
quotas
layer3
groups
rules
policies
rules
endpointgroups
ikepolicies
services
ipsecpolicies
siteconnections
l7policies
monitors
listeners
loadbalancers
pools
policies
firewalls
rules
routerinsertion
monitors
members
vips
pools
floatingips
addressscopes
routers
v1
secrets
orders
acls
containers
v1
certificates
clusters
clustertemplates
v3
v2
users
groups
roles
extensions
applicationcredentials
tokens
endpoints
services
projects
oauth1
ec2tokens
ec2credentials
tenants
tokens
v1
swauth
objects
accounts
containers
v1
users
configurations
databases
instances
datastores
v2
imageimport
images
imagedata
members
v3
extensions
v1
v2
volumes
snapshots
schedulerhints
volumeactions
quotasets
volumes
volumes
snapshots
v1
stacks
v2
recordsets
zones
extensions
apiversions
v2
availabilityzones
messages
snapshots
shares
sharenetworks
securityservices
errors
v2
extensions
images
servers
flavors
availabilityzones
floatingips
volumeattach
startstop
shelveunshelve
tags
servergroups
schedulerhints
tenantnetworks
secgroups
bootfromvolume
quotasets
attachinterfaces
keypairs
v2
l7policies
monitors
listeners
loadbalancers
pools
client
go-cty-yaml
go-cty
cty
set
json
msgpack
function
convert
gocty
stdlib
go-textseg
go-cidr
textseg
cidr
protobuf
proto
ptypes
protoc-gen-go
any
empty
duration
timestamp
descriptor
run
go-jmespath
uuid
go-cmp
cmp
internal
diff
flags
value
function
go-plugin
go-getter
yamux
errwrap
go-checkpoint
terraform-exec
go-uuid
terraform-plugin-sdk
go-version
golang-lru
go-multierror
go-cleanhttp
terraform-plugin-test
terraform-config-inspect
terraform-json
hcl
terraform-svchost
go-safetemp
logutils
go-hclog
internal
plugin
helper
url
tfinstall
httpclient
plugin
internal
meta
terraform
helper
acctest
command
httpclient
tfdiags
providers
configs
provisioners
dag
earlyconfig
moduledeps
plugin
initwd
flatmap
addrs
states
helper
lang
registry
tfplugin5
plans
modsdir
version
format
hcl2shim
configload
configschema
discovery
convert
statefile
plugin
config
didyoumean
funcs
blocktoattr
response
regsrc
objchange
mutexkv
structure
schema
customdiff
hashcode
resource
logging
pathorcontents
acctest
validation
simplelru
tfconfig
json
hcl
v2
token
scanner
parser
token
scanner
ast
strconv
parser
hcldec
ext
gohcl
json
hclsyntax
hcled
hclwrite
hclparse
typeexpr
dynblock
disco
auth
complete
cmd
match
install
afero
mem
go-homedir
cli
reflectwalk
go-testing-interface
copystructure
mapstructure
go-wordwrap
colorstring
go-spew
spew
go-difflib
difflib
aws-sdk-go
service
internal
private
aws
sts
s3
stsiface
sdkmath
sdkio
ini
sdkrand
shareddefaults
s3err
sdkuri
protocol
json
eventstream
rest
restxml
query
xml
jsonutil
eventstreamapi
queryutil
xmlutil
ec2metadata
signer
csm
defaults
session
endpoints
request
awserr
corehandlers
awsutil
credentials
client
v4
endpointcreds
ec2rolecreds
processcreds
stscreds
metadata
msgpack
codes
go-colorable
go-isatty
go-radix
go-netrc
speakeasy
netrc
levenshtein
docs
r
d
objects
info
branches
logs
refs
hooks
97
1b
31
08
94
8d
65
20
99
9f
24
4e
eb
6e
18
b6
e2
78
e6
66
b0
49
fe
01
bd
57
89
5a
c5
1e
e4
f5
d0
1c
44
95
72
dc
12
b7
ee
11
c8
22
1f
53
7a
47
5c
7c
07
fa
59
87
81
9e
75
52
8e
d6
96
ba
e3
29
02
f2
ac
3f
71
4a
ec
10
0e
e7
69
42
a9
9c
a3
6c
db
ea
ff
bf
dd
76
43
3e
34
60
1d
c9
4c
05
ca
26
06
a4
21
d2
85
19
fd
82
9b
a0
c2
f3
fb
b8
b4
cb
0b
c1
a6
0f
74
93
61
5b
51
cf
d1
c7
de
2a
f6
e9
pack
f7
ef
9a
8b
e8
da
d7
b3
ce
79
3a
b5
f1
ae
e0
be
28
a2
info
f8
80
e5
ed
a7
3c
9d
1a
15
a5
56
7d
c6
2b
fc
ad
09
2e
d4
4b
50
98
73
6d
27
f0
3b
70
7e
bc
7f
46
88
0c
c0
af
d5
a8
5e
35
16
b1
40
67
aa
ab
8c
3d
41
e1
b9
6b
23
84
00
37
83
4f
d3
54
0d
33
2f
8f
d9
39
36
55
63
17
77
c4
92
68
f9
c3
04
38
2c
8a
64
b2
7b
48
32
cd
91
6a
14
5d
bb
2d
cc
5f
58
45
f4
03
a1
25
6f
86
62
df
4d
0a
13
30
90
d8
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)